### PR TITLE
fix: return user friendly message on accepting already accepted inv

### DIFF
--- a/rust/src/lang/english.rs
+++ b/rust/src/lang/english.rs
@@ -7,6 +7,7 @@ lazy_static! {
         (TranslationIds::DeviceNotFound, "Device not found"),
         (TranslationIds::DeviceNotUpdated, "Device not updated"),
         (TranslationIds::BackendIssue, "Service unavailable, please try again"),
+        (TranslationIds::InvitationsAlreadyFriends, "You are already friends with this user"),
         (TranslationIds::InvitationsYouAreNotFriends, "You are not friends with this user"),
         (TranslationIds::InvitationsInvitationDoesNotExist, "There is no invitation with that id"),
         (TranslationIds::InvitationsInvitationIsNoLongerValid, "The invitation is no longer valid"),

--- a/rust/src/lang/mod.rs
+++ b/rust/src/lang/mod.rs
@@ -27,7 +27,8 @@ pub enum TranslationIds {
     EmergencyModePushNotificationBody,
     PushNotificationActionView,
     InvalidHistoricalLocationStartTime,
-    CannotUseOwnInvitation
+    CannotUseOwnInvitation,
+    InvitationsAlreadyFriends
 }
 
 

--- a/rust/src/lang/spanish.rs
+++ b/rust/src/lang/spanish.rs
@@ -8,6 +8,7 @@ lazy_static! {
         (TranslationIds::DeviceNotUpdated, "El dispositivo no se pudo actualizar"),
         (TranslationIds::NoUserForKey, "No existe un usuario para esta llave"),
         (TranslationIds::InvitationsYouAreNotFriends, "Usted no es amig@ de este usuario"),
+        (TranslationIds::InvitationsAlreadyFriends, "Usted ya es amigo/a de este usuario"),
         (TranslationIds::InvitationsInvitationDoesNotExist, "La invitación seleccionada no existe"),
         (TranslationIds::InvitationsInvitationIsNoLongerValid, "La invitación ha expirado"),
         (TranslationIds::DatabaseError, "Error de base de datos, un ingeniero será asignado a este problema"),

--- a/rust/src/server/validators/friends.rs
+++ b/rust/src/server/validators/friends.rs
@@ -10,7 +10,7 @@ pub fn assert_not_friends(
         "SELECT * FROM users_followers WHERE username IN ($1, $2) AND username_follower IN ($1, $2)",
         &[user1, user2],
     )
-    .map_err(|w| APIInternalError::from_db_err(w))
+    .map_err(APIInternalError::from_db_err)
     .and_then(|rows| {
         rows.into_iter().next()
             .ok_or(APIInternalError {

--- a/rust/tests/emergency_tests.rs
+++ b/rust/tests/emergency_tests.rs
@@ -1,4 +1,4 @@
-use amiquip::{Connection, QueueDeleteOptions};
+use amiquip::Connection;
 use lib::constants::ASIMOV_LIVES;
 use lib::server::emergency::rocket;
 use lib::{

--- a/rust/tests/invitations_tests.rs
+++ b/rust/tests/invitations_tests.rs
@@ -291,7 +291,7 @@ fn test_accept_already_friends() {
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(
         &response.body_string().unwrap(),
-        r#"{"result":{"engineeringError":"db error: ERROR: duplicate key value violates unique constraint \"users_followers_pkey\"\nDETAIL: Key (username, username_follower)=(dario, coche) already exists.","message":"Service unavailable, please try again"},"success":false}"#
+        r#"{"result":{"engineeringError":null,"message":"You are already friends with this user"},"success":false}"#
     );
 }
 


### PR DESCRIPTION
Also, I've made some code refactor (I've removed some unnecessary "and_then" statements replacing it with the '?' rust operator)