### PR TITLE
[ARM-272] Make sentry optional

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_sentry_logger"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6af079dfc634e57f9521dbb2723ca87b4598e413771ab04311b12ad1444d657"
+checksum = "20d5cfe6811b196b01caee587cd0f413e8c3b2a81c222a378cf28c7896aa064c"
 dependencies = [
  "rocket",
  "sentry",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_sentry_logger"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d5cfe6811b196b01caee587cd0f413e8c3b2a81c222a378cf28c7896aa064c"
+checksum = "c7f0e1ceba0b93deee5a15e9e0a350fa574542579d984c7c349373af95d152f6"
 dependencies = [
  "rocket",
  "sentry",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,5 +32,5 @@ serde_json="1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 pretty_assertions = "0.6.1"
-rocket_sentry_logger = "0.3.2"
+rocket_sentry_logger = "0.4.0"
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,5 +32,5 @@ serde_json="1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 pretty_assertions = "0.6.1"
-rocket_sentry_logger = "0.3.1"
+rocket_sentry_logger = "0.3.2"
 

--- a/rust/src/bin/emergency.rs
+++ b/rust/src/bin/emergency.rs
@@ -1,19 +1,28 @@
+#[macro_use]
+extern crate log;
+
 use lib::server::emergency::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
 
 fn main() {
-    let dsn = std::env::var("SENTRY_DSN");
-    if let Ok(dsn) = dsn {
-        let _guard = logger::init(dsn,Some(InitConfig {
-            service: Some("Emergency API"),
-            ..Default::default()
-        }));
-    }
     env_logger::init();
-    rocket()
-        .attach(logger::fairing())
-        .attach(logging::api_json_response_fairing())
-        .launch();
+    match std::env::var("SENTRY_DSN") {
+        Ok(dsn) => {
+            let sentry_logger = logger::init(dsn,Some(InitConfig {
+                service: Some("Emergency API"),
+                ..Default::default()
+            }));
+            rocket()
+                .manage(sentry_logger)
+                .attach(logger::fairing())
+                .attach(logging::api_json_response_fairing())
+                .launch();
+        },
+        Err(_) => {
+            debug!("SENTRY_DSN env var not found so not using sentry.");
+            rocket().launch();
+        }
+    }
 }
 

--- a/rust/src/bin/emergency.rs
+++ b/rust/src/bin/emergency.rs
@@ -3,13 +3,15 @@ use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
 
 fn main() {
-    let guard = logger::init(Some(InitConfig {
-        service: Some("Emergency API"),
-        ..Default::default()
-    }));
+    let dsn = std::env::var("SENTRY_DSN");
+    if let Ok(dsn) = dsn {
+        let _guard = logger::init(dsn,Some(InitConfig {
+            service: Some("Emergency API"),
+            ..Default::default()
+        }));
+    }
     env_logger::init();
     rocket()
-        .manage(guard)
         .attach(logger::fairing())
         .attach(logging::api_json_response_fairing())
         .launch();

--- a/rust/src/bin/emergency.rs
+++ b/rust/src/bin/emergency.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate log;
-
+use log::debug;
 use lib::server::emergency::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};

--- a/rust/src/bin/http_gateway.rs
+++ b/rust/src/bin/http_gateway.rs
@@ -1,20 +1,28 @@
+#[macro_use]
+extern crate log;
+
 use lib::server::http_gateway::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
+
 fn main() {
-    let dsn = std::env::var("SENTRY_DSN");
-    if let Ok(dsn) = dsn {
-        let _guard = logger::init(
-            dsn,
-            Some(InitConfig {
+    env_logger::init();
+    match std::env::var("SENTRY_DSN") {
+        Ok(dsn) => {
+            let sentry_logger = logger::init(dsn, Some(InitConfig {
                 service: Some("Http gateway"),
                 ..Default::default()
-            }),
-        );
+            }));
+            rocket()
+                .manage(sentry_logger)
+                .attach(logger::fairing())
+                .attach(logging::api_json_response_fairing())
+                .launch();
+        },
+        Err(_) => {
+            debug!("SENTRY_DSN env var not found so not using sentry.");
+            rocket().launch();
+        }
     }
-    env_logger::init();
-    rocket()
-        .attach(logger::fairing())
-        .attach(logging::api_json_response_fairing())
-        .launch();
 }
+

--- a/rust/src/bin/http_gateway.rs
+++ b/rust/src/bin/http_gateway.rs
@@ -2,13 +2,18 @@ use lib::server::http_gateway::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
 fn main() {
-    let guard = logger::init(Some(InitConfig {
-        service: Some("Http gateway"),
-        ..Default::default()
-    }));
+    let dsn = std::env::var("SENTRY_DSN");
+    if let Ok(dsn) = dsn {
+        let _guard = logger::init(
+            dsn,
+            Some(InitConfig {
+                service: Some("Http gateway"),
+                ..Default::default()
+            }),
+        );
+    }
     env_logger::init();
     rocket()
-        .manage(guard)
         .attach(logger::fairing())
         .attach(logging::api_json_response_fairing())
         .launch();

--- a/rust/src/bin/http_gateway.rs
+++ b/rust/src/bin/http_gateway.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate log;
-
+use log::debug;
 use lib::server::http_gateway::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};

--- a/rust/src/bin/invitations.rs
+++ b/rust/src/bin/invitations.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate log;
-
+use log::debug;
 use lib::server::invitations::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};

--- a/rust/src/bin/invitations.rs
+++ b/rust/src/bin/invitations.rs
@@ -1,21 +1,28 @@
+#[macro_use]
+extern crate log;
+
 use lib::server::invitations::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
 
 fn main() {
-    let dsn = std::env::var("SENTRY_DSN");
-    if let Ok(dsn) = dsn {
-        let _guard = logger::init(
-            dsn,
-            Some(InitConfig {
+    env_logger::init();
+    match std::env::var("SENTRY_DSN") {
+        Ok(dsn) => {
+            let sentry_logger = logger::init(dsn, Some(InitConfig {
                 service: Some("Invitations API"),
                 ..Default::default()
-            }),
-        );
+            }));
+            rocket()
+                .manage(sentry_logger)
+                .attach(logger::fairing())
+                .attach(logging::api_json_response_fairing())
+                .launch();
+        },
+        Err(_) => {
+            debug!("SENTRY_DSN env var not found so not using sentry.");
+            rocket().launch();
+        }
     }
-    env_logger::init();
-    rocket()
-        .attach(logger::fairing())
-        .attach(logging::api_json_response_fairing())
-        .launch();
 }
+

--- a/rust/src/bin/invitations.rs
+++ b/rust/src/bin/invitations.rs
@@ -1,14 +1,20 @@
 use lib::server::invitations::rocket;
 use lib::server::middleware::logging;
 use rocket_sentry_logger::{self as logger, InitConfig};
+
 fn main() {
-    let guard = logger::init(Some(InitConfig {
-        service: Some("Invitations API"),
-        ..Default::default()
-    }));
+    let dsn = std::env::var("SENTRY_DSN");
+    if let Ok(dsn) = dsn {
+        let _guard = logger::init(
+            dsn,
+            Some(InitConfig {
+                service: Some("Invitations API"),
+                ..Default::default()
+            }),
+        );
+    }
     env_logger::init();
     rocket()
-        .manage(guard)
         .attach(logger::fairing())
         .attach(logging::api_json_response_fairing())
         .launch();

--- a/rust/src/bin/nanny.rs
+++ b/rust/src/bin/nanny.rs
@@ -30,6 +30,8 @@ fn main() {
                 ..Default::default()
             }),
         );
+    } else {
+        debug!("SENTRY_DSN env var not found so not using sentry.");
     }
 
     let redis_url = env::var("REDIS_URL").expect("REDIS_URL must be set");

--- a/rust/src/bin/nanny.rs
+++ b/rust/src/bin/nanny.rs
@@ -21,10 +21,16 @@ Nanny is a program that has the following jobs:
 fn main() {
     env_logger::init();
     info!("Starting");
-    let _guard = logger::init(Some(InitConfig {
-        service: Some("Nanny"),
-        ..Default::default()
-    }));
+    let dsn = std::env::var("SENTRY_DSN");
+    if let Ok(dsn) = dsn {
+        let _guard = logger::init(
+            dsn,
+            Some(InitConfig {
+                service: Some("Nanny"),
+                ..Default::default()
+            }),
+        );
+    }
 
     let redis_url = env::var("REDIS_URL").expect("REDIS_URL must be set");
 


### PR DESCRIPTION
I upgraded the sentry logger init function to accept the dsn as a parameter. 
So now our code just checks if the "SENTRY_DSN" variable is set and if it is then it calls the init function﻿
