### PR TITLE
[ARM-292] Force refresh the invitation creators telemetry after friend accepts it

### DIFF
--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -17,3 +17,7 @@ pub const ASIMOV_LIVES: &str = "asimovlives";
 pub static DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
 
 pub static DEFAULT_NOTIFICATION_ICON: &str = "ic_stat_logo";
+
+pub static NOTIFICATIONS_EXCHANGE: &str = "notifications.exchange";
+
+pub static NOTIFICATIONS_ROUTING_KEY: &str = "notifications";

--- a/rust/src/server/http_gateway.rs
+++ b/rust/src/server/http_gateway.rs
@@ -146,8 +146,17 @@ fn force_refresh_telemetry(
         }));
     }
 
-    force_refresh_telemetry_internal(&mut client, recipient_username, &auth_info)
-        .map_err(|err| APIJsonResponse::api_error_with_internal_error(err, &auth_info.language))
+    let response = force_refresh_telemetry_internal(
+        &mut client,
+        recipient_username,
+        auth_info.username.clone(),
+    )
+    .map_err(|err| APIJsonResponse::api_error_with_internal_error(err, &auth_info.language))?;
+
+    Ok(Json(APIResponse {
+        success: response.commandStatus != CommandState::Error,
+        result: response,
+    }))
 }
 
 #[allow(unused_must_use)]

--- a/rust/tests/common/rabbit.rs
+++ b/rust/tests/common/rabbit.rs
@@ -6,7 +6,7 @@ use amiquip::{
     Queue, QueueDeclareOptions,
 };
 
-use lib::messaging::{NOTIFICATIONS_EXCHANGE, NOTIFICATIONS_ROUTING_KEY};
+use lib::constants::{NOTIFICATIONS_EXCHANGE, NOTIFICATIONS_ROUTING_KEY};
 
 pub fn bind_notifications_queue(channel: &Channel) -> Queue {
     let queue = channel

--- a/rust/tests/notifications_tests.rs
+++ b/rust/tests/notifications_tests.rs
@@ -1,15 +1,13 @@
-#[macro_use] extern crate pretty_assertions;
+#[macro_use]
+extern crate pretty_assertions;
 
 use amiquip::Connection as RabbitConnection;
+use lib::controllers::telemetry::{create_force_refresh_json, send_force_refresh};
 use lib::{
     db::get_pool,
-    messaging::{
-        build_user_push_notifications, create_force_refresh_json, get_rabbitmq_uri,
-        send_force_refresh,
-    },
+    messaging::{build_user_push_notifications, get_rabbitmq_uri},
     model::{devices::OS, notifications::NotificationData},
 };
-
 mod common;
 use common::dbmate::dbmate_rebuild;
 use lib::constants::DEFAULT_NOTIFICATION_ICON;
@@ -81,7 +79,7 @@ fn format_user_notifications_test() {
             username: "dario".to_string(),
             title: "hola!".to_string(),
             body: "adios!".to_string(),
-            icon:  Some(DEFAULT_NOTIFICATION_ICON.to_string()),
+            icon: Some(DEFAULT_NOTIFICATION_ICON.to_string()),
         },
         &mut client,
         None,
@@ -106,7 +104,7 @@ fn format_user_notifications_with_priority_test() {
             username: "dario".to_string(),
             title: "hola!".to_string(),
             body: "adios!".to_string(),
-            icon:  Some(DEFAULT_NOTIFICATION_ICON.to_string()),
+            icon: Some(DEFAULT_NOTIFICATION_ICON.to_string()),
         },
         &mut client,
         Some("high"),


### PR DESCRIPTION
I've created a "sync_users_location" function to solve this, and also I've refactored the "force_refresh_telemetry_internal" function to be more generic